### PR TITLE
Add header/footer

### DIFF
--- a/README.md
+++ b/README.md
@@ -541,7 +541,7 @@ FileStream("path/to/file.json").concat(in_memory_dict).save(
 )
 ```
 E.g. to <i>append</i> to existing file pass <i>f_open_options={"mode": "a"}</i> to the <i>save()</i> method.
-<br>Given that by default saving <i>plain text</i> uses <i>"\n"</i> as <i>delimiter</i> between items,
+<br>NB: By default saving <i>plain text</i> uses <i>"\n"</i> as <i>delimiter</i> between items,
 <br>you can pass <i>custom delimiter</i> using <i>f_write_options</i>
 ```python
 (FileStream("path/to/lorem/ipsum")
@@ -556,8 +556,28 @@ E.g. to <i>append</i> to existing file pass <i>f_open_options={"mode": "a"}</i> 
 # ...
 # line:0, text='Lorem ipsum dolor sit amet, consectetur adipisicing elit,' || line:2, text='Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris'
 ```
+When working with <i>plain text</i> you can pass <i>'header'</i> and <i>'footer'</i> as <i>f_write_options</i> 
+<br>to be prepended or appended to the FileStream output
+```python
+(FileStream("path/to/lorem/ipsum")
+  .map(lambda line: line.strip())
+  .enumerate()
+  .filter(lambda line: line[0] == 3)
+  .map(lambda line: f"{line[0]}: {line[1]}")
+  .save(f_open_options={"mode": "a"}, f_write_options={"header": "\nHeader\n", "footer": "\nFooter\n"})
+ )
 
-<br>To add <i>custom root</i> tag when saving an <i>.xml</i> file pass <i>'xml_root="my-custom-root"'</i>
+# Lorem ipsum...
+# ...
+# qui officia deserunt mollit anim id est laborum.
+# 
+# Header
+# 3: nisi ut aliquip ex ea commodo consequat.
+# Footer
+#
+```
+
+To add <i>custom root</i> tag when saving an <i>.xml</i> file pass <i>'xml_root="my-custom-root"'</i>
 ```python
 FileStream("path/to/file.json").concat(in_memory_dict).save(
     file_path="path/to/custom.xml",

--- a/TODO
+++ b/TODO
@@ -1,0 +1,4 @@
+- extract Optional to 'drape' library
+- implement Result (as part of 'drape')
+- add 'header'/'footer' as 'f_write_options' -> used for 'append' mode
+    -> e.g. add new line before appended lines, or comma in case of json

--- a/TODO
+++ b/TODO
@@ -1,4 +1,0 @@
-- extract Optional to 'drape' library
-- implement Result (as part of 'drape')
-- add 'header'/'footer' as 'f_write_options' -> used for 'append' mode
-    -> e.g. add new line before appended lines, or comma in case of json

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -521,7 +521,7 @@ FileStream("path/to/file.json").concat(in_memory_dict).save(
 )
 ```
 E.g. to <i>append</i> to existing file pass <i>f_open_options={"mode": "a"}</i> to the <i>save()</i> method.
-<br>Given that by default saving <i>plain text</i> uses <i>"\n"</i> as <i>delimiter</i> between items,
+<br>By default saving <i>plain text</i> uses <i>"\n"</i> as <i>delimiter</i> between items,
 <br>you can pass <i>custom delimiter</i> using <i>f_write_options</i>
 ```python
 (FileStream("path/to/lorem/ipsum")
@@ -537,7 +537,28 @@ E.g. to <i>append</i> to existing file pass <i>f_open_options={"mode": "a"}</i> 
 # line:0, text='Lorem ipsum dolor sit amet, consectetur adipisicing elit,' || line:2, text='Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris'
 ```
 
-<br>To add <i>custom root</i> tag when saving an <i>.xml</i> file pass <i>'xml_root="my-custom-root"'</i>
+When working with <i>plain text</i> you can pass <i>'header'</i> and <i>'footer'</i> as <i>f_write_options</i> 
+<br>to be prepended or appended to the FileStream output
+```python
+(FileStream("path/to/lorem/ipsum")
+  .map(lambda line: line.strip())
+  .enumerate()
+  .filter(lambda line: line[0] == 3)
+  .map(lambda line: f"{line[0]}: {line[1]}")
+  .save(f_open_options={"mode": "a"}, f_write_options={"header": "\nHeader\n", "footer": "\nFooter\n"})
+ )
+
+# Lorem ipsum...
+# ...
+# qui officia deserunt mollit anim id est laborum.
+# 
+# Header
+# 3: nisi ut aliquip ex ea commodo consequat.
+# Footer
+#
+```
+
+To add <i>custom root</i> tag when saving an <i>.xml</i> file pass <i>'xml_root="my-custom-root"'</i>
 ```python
 FileStream("path/to/file.json").concat(in_memory_dict).save(
     file_path="path/to/custom.xml",

--- a/pyrio/__init__.py
+++ b/pyrio/__init__.py
@@ -2,3 +2,5 @@ from pyrio.streams.stream import Stream as Stream
 from pyrio.streams.file_stream import FileStream as FileStream
 from pyrio.utils.optional import Optional as Optional
 from pyrio.utils.dict_item import DictItem as DictItem
+
+__all__ = ["Stream", "FileStream", "Optional", "DictItem"]

--- a/pyrio/streams/file_stream.py
+++ b/pyrio/streams/file_stream.py
@@ -199,9 +199,16 @@ class FileStream(BaseStream):
             dump(output, f, **f_write_options)
 
     def _write_plain(self, path, tmp_path, f_open_options, f_write_options):
-        self._prepare_io_options([(f_open_options, "mode", "w"), (f_write_options, "delimiter", "\n")])
+        self._prepare_io_options([(f_open_options, "mode", "w")])
+
+        output = self.to_string(f_write_options.pop("delimiter", "\n"))
+        header = f_write_options.pop("header", "")
+        footer = f_write_options.pop("footer", "")
+        if header or footer:
+            output = f"{header}{output}{footer}"
+
         with self._atomic_write(path, tmp_path, f_open_options) as f:
-            f.writelines(self.to_string(**f_write_options))
+            f.writelines(output)
 
     # ### helpers ###
     @staticmethod

--- a/tests/resources/save_output/foo.txt
+++ b/tests/resources/save_output/foo.txt
@@ -1,0 +1,12 @@
+Lorem ipsum dolor sit amet, consectetur adipisicing elit,
+sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris
+nisi ut aliquip ex ea commodo consequat.
+Duis aute irure dolor in reprehenderit in voluptate velit esse
+cillum dolore eu fugiat nulla pariatur.
+Excepteur sint occaecat cupidatat non proident, sunt in culpa
+qui officia deserunt mollit anim id est laborum.
+
+Header
+3: nisi ut aliquip ex ea commodo consequat.
+Footer

--- a/tests/test_file_stream.py
+++ b/tests/test_file_stream.py
@@ -482,3 +482,18 @@ def test_append_to_plain(tmp_file_dir, json_dict):
         .save(f_open_options={"mode": "a"})
     )
     assert tmp_file_path.read_text() == open(f"./tests/resources/save_output/{file_path}").read()
+
+
+def test_plain_text_header_footer(tmp_file_dir):
+    file_path = "foo.txt"
+    tmp_file_path = tmp_file_dir / file_path
+    shutil.copyfile("./tests/resources/plain.txt", tmp_file_path)
+    (
+        FileStream(tmp_file_path)
+        .map(lambda line: line.strip())
+        .enumerate()
+        .filter(lambda line: line[0] == 3)
+        .map(lambda line: f"{line[0]}: {line[1]}")
+        .save(f_open_options={"mode": "a"}, f_write_options={"header": "\nHeader\n", "footer": "\nFooter\n"})
+    )
+    assert tmp_file_path.read_text() == open(f"./tests/resources/save_output/{file_path}").read()


### PR DESCRIPTION
## Summary by Sourcery

Add support for specifying header and footer when saving plain text files.

New Features:
- Added `header` and `footer` options to the `f_write_options` parameter of the `save()` method to support prepending and appending text to plain text files.

Tests:
- Added tests to verify the functionality of the `header` and `footer` options.